### PR TITLE
Say explicitly that `wyng add` needs a volume name

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,8 @@ wyng add vm-untrusted-private
 ```
 Adds a new entry to the list of volumes configured for backup.
 
+The entry needs to be **volume name**, not a **VM name**.  You can find your volume names with `sudo lvs`.
+
 
 #### delete
 ```


### PR DESCRIPTION
Say explicitly that `wyng add` requires a volume name and not a VM name, to avoid [confusion](https://github.com/tasket/wyng-backup/issues/127#issuecomment-1300346001).