### PR TITLE
Add hmac import to wyng script

### DIFF
--- a/wyng
+++ b/wyng
@@ -9,7 +9,7 @@
 
 #  editor width: 100  -----------------------------------------------------------------------------
 import sys, signal, os, stat, shutil, subprocess, time, datetime
-import re, mmap, bz2, zlib, gzip, tarfile, io, fcntl, tempfile
+import re, mmap, bz2, zlib, gzip, hmac, tarfile, io, fcntl, tempfile
 import argparse, configparser, hashlib, functools, uuid, string
 import xml.etree.ElementTree    ; from itertools import islice
 from array import array         ; import resource


### PR DESCRIPTION
On python 3.9 on Almalinux 9 (RHEL 9 based), the hmac module is not available in python without importing it. Add import so script will function.

(Do other OSes like Qubes import hmac automatically for you?).

```
[root@host wyng-backup]# cat /etc/redhat-release
AlmaLinux release 9.1 (Lime Lynx)
[root@tt20 wyng-backup]# python3.9
Python 3.9.14 (main, Nov  7 2022, 00:00:00)
[GCC 11.3.1 20220421 (Red Hat 11.3.1-2)] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> dir(hmac)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
NameError: name 'hmac' is not defined
>>>
```